### PR TITLE
build: move test .asd file to root

### DIFF
--- a/fare-utils-test.asd
+++ b/fare-utils-test.asd
@@ -7,6 +7,8 @@
   :author "Francois-Rene Rideau"
   :depends-on ("fare-utils" "hu.dwim.stefil")
   :components
-  ((:file "package")
-   (:file "strings" :depends-on ("package")))
+  ((:module "test"
+    :components
+    ((:file "package")
+     (:file "strings" :depends-on ("package")))))
   :perform (test-op (o c) (symbol-call :fare-utils-test :test-suite)))


### PR DESCRIPTION
This is the convention for ASDF projects.